### PR TITLE
Set locale based on Accept-Language header

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,9 +3,23 @@ class ApplicationController < ActionController::Base
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
   before_action :mobile_filter_header
+  before_action :set_locale
 
   def mobile_filter_header
     @mobile = true
   end
+
+  def mobile_filter_header
+    @mobile = true
+  end
+
+   def set_locale
+     I18n.locale = extract_locale_from_accept_language_header
+   end
+
+  private
+    def extract_locale_from_accept_language_header
+      request.env['HTTP_ACCEPT_LANGUAGE'].scan(/^[a-z]{2}/).first
+    end
 
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -20,7 +20,9 @@ module SaferstallsRails
         resource "/api/*", headers: :any, methods: [:get, :post, :options]
       end
     end
-# I18n stuff
-config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}')]
+
+    # I18n stuff
+    config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}')]
+
   end
 end


### PR DESCRIPTION
# Context
- A solution to language switching discussed in #413.

# Summary of Changes

- Set locale based on the Accept-Langauge header of the request, which is usually set by the browser. According to the [rails guide on i18n](http://guides.rubyonrails.org/i18n.html#managing-the-locale-across-requests)

> The Accept-Language HTTP header indicates the preferred language for request's response. Browsers set this header value based on the user's language preference settings, making it a good first choice when inferring a locale.

Now, the language of the page will change to fit with the preferred language setting of the browser.

## Change Setting
Chrome Settings
![image](https://user-images.githubusercontent.com/11802391/34802994-b6a80596-f63e-11e7-83e4-5892fa045bc2.png)
<img width="1280" alt="screen shot 2018-01-10 at 6 28 37 pm" src="https://user-images.githubusercontent.com/11802391/34800982-2dcd8d86-f634-11e7-9021-602c37c04e39.png">